### PR TITLE
delete menu functionality

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -330,22 +330,22 @@ app.put("/menus/:menuId", (req, res) => {
   });
 });
 
-app.delete("/menus/:id", (req, res) => {
-  const menuId = req.params.menuId;
-  const sql = "DELETE FROM menu WHERE MenuID = ?";
-  db.query(sql, [menuId], (err, result) => {
+app.delete("/menus/:id", async (req, res) => {
+  const id = parseInt(req.params.id); 
+  const sql = `DELETE FROM menu WHERE MenuID = ?`;
+  db.query(sql, [id], function (err, result) {
     if (err) {
-      return res.status(500).json({
-        message: `Failed to delete the menu: ${err}`,
+      res.status(400).json({
+        message: `Failed to delete the menu ${id}: ${err}`,
       });
     }
     if (result.affectedRows === 0) {
-      return res.status(404).json({
+      res.status(404).json({
         message: "Menu not found",
       });
     }
     res.status(200).json({
-      message: "Menu deleted successfully",
+      message: `Successfully delted menu with ID ${id}`,
     });
   });
 });

--- a/frontend/src/pages/create/EventForm.js
+++ b/frontend/src/pages/create/EventForm.js
@@ -88,8 +88,6 @@ export default function EventForm(props) {
   };
 
   const handleDeleteEvent = (e) => {
-    setIsLoading(true);
-
     axios
       .delete(`${config[process.env.NODE_ENV].apiDomain}/events/${event.EventID}`,{})
       .then((response)=>{
@@ -105,8 +103,7 @@ export default function EventForm(props) {
           "Could not delete event."
         );
         console.log(err);
-      })
-      .finally(()=>setIsLoading(false));
+      });
   };
 
   return (

--- a/frontend/src/pages/create/MenuForm.js
+++ b/frontend/src/pages/create/MenuForm.js
@@ -101,7 +101,25 @@ export default function MenuForm(props) {
 
   const handleEditMenu = () => {};
 
-  const handleDeleteMenu = () => {};
+  const handleDeleteMenu = (e) => {
+    console.log('menuid: '+menu.MenuID);
+    axios
+      .delete(`${config[process.env.NODE_ENV].apiDomain}/menus/${menu.MenuID}`,{})
+      .then((response)=>{
+        handleClear();
+        showAlert(
+          "success",
+          "Successfully deleted menu."
+        );
+      })
+      .catch((err) => {
+        showAlert(
+          "error",
+          "Could not delete menu."
+        );
+        console.log(err);
+      });
+  };
 
   const handleMenuItemChange = (index, label, description, custom = false) => {
     const updatedMenuOptions = [...menuOptions];


### PR DESCRIPTION
code almost the same as `handleDeleteEvent` but somehow it isn't working. i'm constantly getting a `404` error.  `MenuID` in db looks to be the same as whatver menu slide is selected on UI

#### THINGS IVE TRIED
- including `params: { id: menu.MenuID}` in the request 
- restarting docker / vscode / browser
- refactoring `app.delete` to match `app.delete` for `events`